### PR TITLE
Devise setup

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,14 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
+
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  protected
+
+  def configure_permitted_parameters
+    added_attrs = [:username, :email, :password, :password_confirmation, :remember_me]
+    devise_parameter_sanitizer.permit :sign_up, keys: added_attrs
+    devise_parameter_sanitizer.permit :account_update, keys: added_attrs
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,28 +1,15 @@
 class User < ApplicationRecord
-  attr_writer :login
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
-  def login
-    @login || self.username || self.email
-  end
+  validates :email, uniqueness: true
+  validates :username, uniqueness: true
 
-  def self.find_for_database_authentication(warden_conditions)
-    conditions = warden_conditions.dup
-    if login = conditions.delete(:login)
-      where(conditions.to_h).where(["lower(username) = :value OR lower(email) = :value", { :value => login.downcase }]).first
-    elsif conditions.has_key?(:username) || conditions.has_key?(:email)
-      where(conditions.to_h).first
-    end
-  end
-
-  validate :validate_username
-
-  def validate_username
-    if User.where(email: username).exists?
-      errors.add(:username, :invalid)
-    end
-  end
 
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :trackable, :validatable
+         :recoverable, :rememberable, :trackable, :validatable,
+         :authentication_keys => [:username]
+
+  def will_save_change_to_email?
+    false
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,28 @@
 class User < ApplicationRecord
+  attr_writer :login
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
+  def login
+    @login || self.username || self.email
+  end
+
+  def self.find_for_database_authentication(warden_conditions)
+    conditions = warden_conditions.dup
+    if login = conditions.delete(:login)
+      where(conditions.to_h).where(["lower(username) = :value OR lower(email) = :value", { :value => login.downcase }]).first
+    elsif conditions.has_key?(:username) || conditions.has_key?(:email)
+      where(conditions.to_h).first
+    end
+  end
+
+  validate :validate_username
+
+  def validate_username
+    if User.where(email: username).exists?
+      errors.add(:username, :invalid)
+    end
+  end
+
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
 end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -4,8 +4,13 @@
   <%= devise_error_messages! %>
 
   <div class="field">
+    <%= f.label :username %><br />
+    <%= f.text_field :username, autofocus: true, autocomplete: "off" %>
+  </div>
+
+  <div class="field">
     <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    <%= f.email_field :email, autocomplete: "email" %>
   </div>
 
   <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -2,10 +2,14 @@
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
   <%= devise_error_messages! %>
+  <div class="field">
+    <%= f.label :username %><br />
+    <%= f.username_field :username, autofocus: true, autocomplete: "off" %>
+  </div>
 
   <div class="field">
     <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    <%= f.email_field :email, autocomplete: "email" %>
   </div>
 
   <div class="field">

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -4,7 +4,7 @@
   <%= devise_error_messages! %>
   <div class="field">
     <%= f.label :username %><br />
-    <%= f.username_field :username, autofocus: true, autocomplete: "off" %>
+    <%= f.text_field :username, autofocus: true, autocomplete: "off" %>
   </div>
 
   <div class="field">

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -2,8 +2,13 @@
 
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
   <div class="field">
+    <%= f.label :username %><br />
+    <%= f.username_field :username, autofocus: true, autocomplete: "off" %>
+  </div>
+
+  <div class="field">
     <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    <%= f.email_field :email, autocomplete: "email" %>
   </div>
 
   <div class="field">

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -2,8 +2,8 @@
 
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
   <div class="field">
-    <%= f.label :username %><br />
-    <%= f.username_field :username, autofocus: true, autocomplete: "off" %>
+    <%= f.label :login, 'Username' %><br />
+    <%= f.text_field :login, autofocus: true, autocomplete: "off" %>
   </div>
 
   <div class="field">

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -2,13 +2,8 @@
 
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
   <div class="field">
-    <%= f.label :login, 'Username' %><br />
-    <%= f.text_field :login, autofocus: true, autocomplete: "off" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autocomplete: "email" %>
+    <%= f.label :username %><br />
+    <%= f.text_field :username, autofocus: true, autocomplete: "off" %>
   </div>
 
   <div class="field">

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -41,7 +41,7 @@ Devise.setup do |config|  config.secret_key = Rails.application.secret_key_base
   # session. If you need permissions, you should implement that in a before filter.
   # You can also supply a hash where the value is a boolean determining whether
   # or not authentication should be aborted when the value is not present.
-  # config.authentication_keys = [:login]
+  # config.authentication_keys = [:username]
 
   # Configure parameters from the request object used for authentication. Each entry
   # given should be a request method and it will automatically be passed to the
@@ -53,12 +53,12 @@ Devise.setup do |config|  config.secret_key = Rails.application.secret_key_base
   # Configure which authentication keys should be case-insensitive.
   # These keys will be downcased upon creating or modifying a user and when used
   # to authenticate or find a user. Default is :email.
-  config.case_insensitive_keys = [:login]
+  config.case_insensitive_keys = [:username]
 
   # Configure which authentication keys should have whitespace stripped.
   # These keys will have whitespace before and after removed upon creating or
   # modifying a user and when used to authenticate or find a user. Default is :email.
-  config.strip_whitespace_keys = [:login]
+  config.strip_whitespace_keys = [:username]
 
   # Tell if authentication through request.params is enabled. True by default.
   # It can be set to an array that will enable params authentication only for the

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -10,7 +10,7 @@ Devise.setup do |config|  config.secret_key = Rails.application.secret_key_base
   # Devise will use the `secret_key_base` as its `secret_key`
   # by default. You can change it below and use your own secret key.
   # config.secret_key = '8c2c0a74a9fe737b618637c396f828ad767806bf48cc32cd5203a46f4b610900442ac7543420458799f49ba375c2a0eb4217cfd3b64f09d3c37ac30f6690df92'
-  
+
   # ==> Controller configuration
   # Configure the parent class to the devise controllers.
   # config.parent_controller = 'DeviseController'
@@ -41,7 +41,7 @@ Devise.setup do |config|  config.secret_key = Rails.application.secret_key_base
   # session. If you need permissions, you should implement that in a before filter.
   # You can also supply a hash where the value is a boolean determining whether
   # or not authentication should be aborted when the value is not present.
-  # config.authentication_keys = [:email]
+  # config.authentication_keys = [:login]
 
   # Configure parameters from the request object used for authentication. Each entry
   # given should be a request method and it will automatically be passed to the
@@ -53,12 +53,12 @@ Devise.setup do |config|  config.secret_key = Rails.application.secret_key_base
   # Configure which authentication keys should be case-insensitive.
   # These keys will be downcased upon creating or modifying a user and when used
   # to authenticate or find a user. Default is :email.
-  config.case_insensitive_keys = [:email]
+  config.case_insensitive_keys = [:login]
 
   # Configure which authentication keys should have whitespace stripped.
   # These keys will have whitespace before and after removed upon creating or
   # modifying a user and when used to authenticate or find a user. Default is :email.
-  config.strip_whitespace_keys = [:email]
+  config.strip_whitespace_keys = [:login]
 
   # Tell if authentication through request.params is enabled. True by default.
   # It can be set to an array that will enable params authentication only for the

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -9,10 +9,10 @@ en:
     failure:
       already_authenticated: "You are already signed in."
       inactive: "Your account is not activated yet."
-      invalid: "Invalid %{authentication_keys} or password."
+      invalid: "Invalid username or password."
       locked: "Your account is locked."
       last_attempt: "You have one more attempt before your account is locked."
-      not_found_in_database: "Invalid %{authentication_keys} or password."
+      not_found_in_database: "Invalid username or password."
       timeout: "Your session expired. Please sign in again to continue."
       unauthenticated: "You need to sign in or sign up before continuing."
       unconfirmed: "You have to confirm your email address before continuing."

--- a/db/migrate/20180723184217_add_username_to_users.rb
+++ b/db/migrate/20180723184217_add_username_to_users.rb
@@ -1,7 +1,7 @@
 class AddUsernameToUsers < ActiveRecord::Migration[5.2]
   def up
     add_column :users, :username, :string, null: false
-    add_index :users, :username
+    add_index :users, :username, unique: true
   end
 
   def down

--- a/db/migrate/20180723184217_add_username_to_users.rb
+++ b/db/migrate/20180723184217_add_username_to_users.rb
@@ -1,0 +1,10 @@
+class AddUsernameToUsers < ActiveRecord::Migration[5.2]
+  def up
+    add_column :users, :username, :string, null: false
+    add_index :users, :username
+  end
+
+  def down
+    remove_column :users, :username, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -31,7 +31,7 @@ ActiveRecord::Schema.define(version: 2018_07_23_184217) do
     t.string "username", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
-    t.index ["username"], name: "index_users_on_username"
+    t.index ["username"], name: "index_users_on_username", unique: true
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_23_160207) do
+ActiveRecord::Schema.define(version: 2018_07_23_184217) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,8 +28,10 @@ ActiveRecord::Schema.define(version: 2018_07_23_160207) do
     t.inet "last_sign_in_ip"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "username", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["username"], name: "index_users_on_username"
   end
 
 end

--- a/spec/features/user_signs_in_spec.rb
+++ b/spec/features/user_signs_in_spec.rb
@@ -10,6 +10,7 @@ feature 'user signs in', %Q{
 
     visit new_user_session_path
 
+    fill_in 'Username', with: user.username
     fill_in 'Email', with: user.email
     fill_in 'Password', with: user.password
 

--- a/spec/features/user_signs_in_spec.rb
+++ b/spec/features/user_signs_in_spec.rb
@@ -11,7 +11,6 @@ feature 'user signs in', %Q{
     visit new_user_session_path
 
     fill_in 'Username', with: user.username
-    fill_in 'Email', with: user.email
     fill_in 'Password', with: user.password
 
     click_button 'Log in'
@@ -24,7 +23,7 @@ feature 'user signs in', %Q{
     visit new_user_session_path
 
     click_button 'Log in'
-    expect(page).to have_content('Invalid Email or password')
+    expect(page).to have_content('Invalid username or password')
     expect(page).to_not have_content('Sign Out')
   end
 end

--- a/spec/features/user_signs_out_spec.rb
+++ b/spec/features/user_signs_out_spec.rb
@@ -15,6 +15,7 @@ feature 'user signs out', %Q{
 
     visit new_user_session_path
 
+    fill_in 'Username', with: user.username
     fill_in 'Email', with: user.email
     fill_in 'Password', with: user.password
 

--- a/spec/features/user_signs_out_spec.rb
+++ b/spec/features/user_signs_out_spec.rb
@@ -16,7 +16,6 @@ feature 'user signs out', %Q{
     visit new_user_session_path
 
     fill_in 'Username', with: user.username
-    fill_in 'Email', with: user.email
     fill_in 'Password', with: user.password
 
     click_button 'Log in'

--- a/spec/features/user_signs_up_spec.rb
+++ b/spec/features/user_signs_up_spec.rb
@@ -15,6 +15,7 @@ feature 'user registers', %Q{
   scenario 'provide valid registration information' do
     visit new_user_registration_path
 
+    fill_in 'Username', with: 'user'
     fill_in 'Email', with: 'john@example.com'
     fill_in 'Password', with: 'password'
     fill_in 'Password confirmation', with: 'password'

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -2,6 +2,7 @@ require 'factory_bot'
 
 FactoryBot.define do
   factory :user do
+    username 'user'
     sequence(:email) {|n| "user#{n}@example.com" }
     password 'password'
     password_confirmation 'password'


### PR DESCRIPTION
Added :username to users table, set authentication key to :username instead of :email, updated devise views to match our edits. Referenced from <https://github.com/plataformatec/devise/wiki/How-To:-Allow-users-to-sign-in-using-their-username-or-email-address>